### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ The MCP server provides **84 specialized tools** across 10 categories:
 - ✅ Generates compliance score and remediation plan
 - ✅ Creates detailed findings report with priorities
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/johnneerdael-netskope-mcp).
+
 ## Quick Start
 
 1. **Environment Setup**


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/johnneerdael-netskope-mcp)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Hosted deployment" section to the README with information about an externally hosted deployment option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->